### PR TITLE
Thermistor CAN packet and updated CAN send

### DIFF
--- a/fsae-pcc/src/can.cpp
+++ b/fsae-pcc/src/can.cpp
@@ -9,7 +9,6 @@
 #include <arduino_freertos.h>
 
 #define CAN_BAUDRATE 500000
-#define PCC_CAN_ID 0x222
 // #define PCC_CAN_ID 0x123
 
 // charger can ids
@@ -19,17 +18,6 @@
 #define CHARGER_SAFETY_BYTE 6
 // charger safety mask
 constexpr uint8_t CHARGER_SAFETY_MASK = 0x08;
-
-typedef struct __attribute__((packed)) {
-    uint8_t state;               // Precharge state
-    uint8_t errorCode;           // Error code
-    uint16_t accumulatorVoltage; // Accumulator voltage in volts
-    uint16_t tsVoltage;          // Transmission side voltage in volts
-    uint16_t prechargeProgress;  // Precharge progress in percent
-    // uint8_t isSafeTemperature;   // Precharge temperature ok check
-} PCC;
-
-static PCC pccData;
 
 // struct for charger data
 typedef struct {
@@ -44,8 +32,8 @@ typedef struct {
 static ChargerData chargerData;
 
 FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_16> can2;
-static CAN_message_t pccMsg;
 
+static CAN_message_t canMsg;
 // dedicated task: drains the CAN rx fifo independent of the precharge loop
 static void canTask(void *pvParameters);
 
@@ -67,6 +55,16 @@ void CAN_Init() {
                 THREAD_CAN_PRIORITY, NULL);
 }
 
+void canSendMessage(uint32_t id, const void *data, uint8_t length) {
+    canMsg.id = id;
+    // required to prevent reading garbage values as struct can be smaller than
+    // 8 bytes
+    canMsg.len = length;
+    memcpy(canMsg.buf, data, length);
+    can2.write(canMsg);
+}
+
+/*
 void CAN_SendPCCMessage(uint8_t state, uint8_t errorCode,
                         float accumulatorVoltage, float tsVoltage,
                         float prechargeProgress) {
@@ -95,6 +93,7 @@ void CAN_SendPCCMessage(uint8_t state, uint8_t errorCode,
     // Serial.print(pccData.prechargeProgress);
     // Serial.print('\n');
 }
+*/
 
 static void pollMessages() {
     CAN_message_t rxMsg;

--- a/fsae-pcc/src/can.h
+++ b/fsae-pcc/src/can.h
@@ -17,14 +17,13 @@ typedef struct __attribute__((packed)) {
     uint16_t accumulatorVoltage; // Accumulator voltage in volts
     uint16_t tsVoltage;          // Transmission side voltage in volts
     uint16_t prechargeProgress;  // Precharge progress in percent
-    // uint8_t isSafeTemperature;   // Precharge temperature ok check
-} PCC;
+} PCCData;
 
 typedef struct __attribute__((packed)) {
     int16_t T1Temp; // Thermistor 1 Temperature
     int16_t T2Temp; // Thermistor 2 Temperature
-    uint8_t safeToCharge : 1;
-} Temp;
+    uint8_t isSafeTemperature : 0;
+} PCCTempData;
 
 void CAN_Init();
 

--- a/fsae-pcc/src/can.h
+++ b/fsae-pcc/src/can.h
@@ -22,7 +22,7 @@ typedef struct __attribute__((packed)) {
 typedef struct __attribute__((packed)) {
     int16_t T1Temp; // Thermistor 1 Temperature
     int16_t T2Temp; // Thermistor 2 Temperature
-    uint8_t isSafeTemperature : 0;
+    uint8_t isSafeTemperature : 1;
 } PCCTempData;
 
 void CAN_Init();

--- a/fsae-pcc/src/can.h
+++ b/fsae-pcc/src/can.h
@@ -5,13 +5,30 @@
 #include <FreeRTOS.h>
 #include <stdint.h>
 
+#define PCC_CAN_ID 0x222
+#define TEMP_CAN_ID 0x223
+
 // bms can timeout - using inline so it is defined at compile time
 inline constexpr uint32_t BMS_CAN_TIMEOUT_MS = 1500;
 
+typedef struct __attribute__((packed)) {
+    uint8_t state;               // Precharge state
+    uint8_t errorCode;           // Error code
+    uint16_t accumulatorVoltage; // Accumulator voltage in volts
+    uint16_t tsVoltage;          // Transmission side voltage in volts
+    uint16_t prechargeProgress;  // Precharge progress in percent
+    // uint8_t isSafeTemperature;   // Precharge temperature ok check
+} PCC;
+
+typedef struct __attribute__((packed)) {
+    int16_t T1Temp; // Thermistor 1 Temperature
+    int16_t T2Temp; // Thermistor 2 Temperature
+    uint8_t safeToCharge : 1;
+} Temp;
+
 void CAN_Init();
-void CAN_SendPCCMessage(uint8_t state, uint8_t errorCode,
-                        float accumulatorVoltage, float tsVoltage,
-                        float prechargeProgress);
+
+void canSendMessage(uint32_t id, const void *data, uint8_t length);
 
 bool CAN_IsChargerSafetyActive();
 // get last bms can rx time - using Ticktype_t instead of uint32_t from freeRTOS

--- a/fsae-pcc/src/precharge.cpp
+++ b/fsae-pcc/src/precharge.cpp
@@ -167,10 +167,10 @@ void prechargeTask(void *pvParameters) {
             .prechargeProgress = uint16_t(pcData.prechargeProgress),
         };
 
-        canSendMessage(PCC_CAN_ID, &pccData, sizeof(PCC));
+        canSendMessage(PCC_CAN_ID, &pccData, sizeof(PCCData));
 
         // Send CAN message of thermistor state
-        canSendMessage(TEMP_CAN_ID, &tempData, sizeof(Temp));
+        canSendMessage(TEMP_CAN_ID, &tempData, sizeof(PCCTempData));
 
 
         // CAN_SendPCCMessage(STATE_DISCHARGE, errorCode, 10.0F, 20.0F, 50.0F);

--- a/fsae-pcc/src/precharge.cpp
+++ b/fsae-pcc/src/precharge.cpp
@@ -30,7 +30,8 @@ constexpr double THERMISTOR_TEMPERATURE_THRESHOLD_C = 69;
 PrechargeState state = STATE_STANDBY;
 PrechargeState lastState = STATE_UNDEFINED;
 int errorCode = ERR_NONE;
-
+static PCC pccData = {0};
+static Temp tempData = {0};
 // Voltage measurements
 
 // Low pass filter
@@ -154,8 +155,21 @@ void prechargeTask(void *pvParameters) {
         // taskEXIT_CRITICAL(); // Exit critical section
 
         // Send CAN message of current PCC state
-        CAN_SendPCCMessage(state, errorCode, pcData.accVoltage,
-                           pcData.tsVoltage, pcData.prechargeProgress);
+        pccData = {
+            .state = (uint8_t)state,
+            .errorCode = (uint8_t)errorCode,
+            .accumulatorVoltage = uint16_t(pcData.accVoltage * 100),
+            .tsVoltage = uint16_t(pcData.tsVoltage * 100),
+            .prechargeProgress = uint16_t(pcData.prechargeProgress),
+        };
+
+        canSendMessage(PCC_CAN_ID, &pccData, sizeof(PCC));
+
+        // Send CAN message of thermistor state
+        canSendMessage(TEMP_CAN_ID, &tempData, sizeof(Temp));
+
+        pccData = {0};
+        tempData = {0};
         // CAN_SendPCCMessage(STATE_DISCHARGE, errorCode, 10.0F, 20.0F, 50.0F);
 
         // Wait for next cycle
@@ -419,6 +433,14 @@ bool checkSafeTemperature() {
     double T1Temp = temperatureFromADC(T1ADC);
     double T2Temp = temperatureFromADC(T2ADC);
 
-    return (T1Temp < THERMISTOR_TEMPERATURE_THRESHOLD_C &&
-            T2Temp < THERMISTOR_TEMPERATURE_THRESHOLD_C);
+    tempData.T1Temp = (int16_t)(T1Temp);
+    tempData.T2Temp = (int16_t)(T2Temp);
+
+    if (T1Temp < THERMISTOR_TEMPERATURE_THRESHOLD_C &&
+        T2Temp < THERMISTOR_TEMPERATURE_THRESHOLD_C) {
+        tempData.safeToCharge = 1;
+    } else {
+        tempData.safeToCharge = 0;
+    }
+    return (tempData.safeToCharge);
 }

--- a/fsae-pcc/src/precharge.cpp
+++ b/fsae-pcc/src/precharge.cpp
@@ -30,8 +30,8 @@ constexpr double THERMISTOR_TEMPERATURE_THRESHOLD_C = 69;
 PrechargeState state = STATE_STANDBY;
 PrechargeState lastState = STATE_UNDEFINED;
 int errorCode = ERR_NONE;
-static PCC pccData = {0};
-static Temp tempData = {0};
+static PCCData pccData{};
+static PCCTempData tempData{};
 // Voltage measurements
 
 // Low pass filter
@@ -64,8 +64,8 @@ void prechargeInit() {
     pcData.accVoltage = 0.0F;  // Initialize filtered tractive system frequency
     pcData.tsVoltage = 0.0F;   // Initialize filtered accumulator frequency
     pcData.prechargeProgress = 0.0F; // Initialize accumulator voltage
-    pcData.isSafeTemperature =
-        false; // Initialize temperature check flag to false
+
+    tempData.isSafeTemperature = false;
 
     // Create precharge task
     xTaskCreate(prechargeTask, "PrechargeTask", PRECHARGE_STACK_SIZE, NULL,
@@ -84,6 +84,10 @@ void prechargeTask(void *pvParameters) {
         // Check thermistor readings, discharge if exceeded
         if (!checkSafeTemperature()) {
             state = STATE_DISCHARGE;
+        }
+        else {
+            // Update temperature CAN flag
+            tempData.isSafeTemperature = true;
         }
 
         updateVoltage(ACCUMULATOR_VOLTAGE_PIN); // Get raw accumulator voltage
@@ -168,8 +172,7 @@ void prechargeTask(void *pvParameters) {
         // Send CAN message of thermistor state
         canSendMessage(TEMP_CAN_ID, &tempData, sizeof(Temp));
 
-        pccData = {0};
-        tempData = {0};
+
         // CAN_SendPCCMessage(STATE_DISCHARGE, errorCode, 10.0F, 20.0F, 50.0F);
 
         // Wait for next cycle
@@ -438,9 +441,9 @@ bool checkSafeTemperature() {
 
     if (T1Temp < THERMISTOR_TEMPERATURE_THRESHOLD_C &&
         T2Temp < THERMISTOR_TEMPERATURE_THRESHOLD_C) {
-        tempData.safeToCharge = 1;
-    } else {
-        tempData.safeToCharge = 0;
+        tempData.isSafeTemperature = 1;
+        return 1;
     }
-    return (tempData.safeToCharge);
+    tempData.isSafeTemperature = 0;
+    return 0;
 }

--- a/fsae-pcc/src/precharge.cpp
+++ b/fsae-pcc/src/precharge.cpp
@@ -84,8 +84,7 @@ void prechargeTask(void *pvParameters) {
         // Check thermistor readings, discharge if exceeded
         if (!checkSafeTemperature()) {
             state = STATE_DISCHARGE;
-        }
-        else {
+        } else {
             // Update temperature CAN flag
             tempData.isSafeTemperature = true;
         }
@@ -171,7 +170,6 @@ void prechargeTask(void *pvParameters) {
 
         // Send CAN message of thermistor state
         canSendMessage(TEMP_CAN_ID, &tempData, sizeof(PCCTempData));
-
 
         // CAN_SendPCCMessage(STATE_DISCHARGE, errorCode, 10.0F, 20.0F, 50.0F);
 


### PR DESCRIPTION
## Summary of Changes
- New generic CAN_send method added
- Packed struct for temperature data and safe temperature flag added

## Implementation Details
- New struct definition added in can.h, associated values updated in precharge.cpp

## Testing and Validation (include a link or image as proof of the validation performed.)
- 
<img width="673" height="276" alt="Screenshot 2026-05-11 at 11 53 32" src="https://github.com/user-attachments/assets/9e0c48d8-b6eb-4d9d-98b6-34774fcaaeb7" />



